### PR TITLE
Add ip adresses if host name can't be resolved

### DIFF
--- a/Get-RemoteSmtpServers.ps1
+++ b/Get-RemoteSmtpServers.ps1
@@ -65,8 +65,6 @@ param(
   [int]$AddDays = -10
 )
 
-$ScriptDir = Split-Path -Path $script:MyInvocation.MyCommand.Path
-
 $CsvFileName = ('RemoteSMTPServers-%SERVER%-%ROLE%-{0}.csv' -f ((Get-Date).ToString('s').Replace(':','-')))
 
 # ToDo: Update to Get-TransportServer/Get-TransportService 

--- a/Get-RemoteSmtpServersTls.ps1
+++ b/Get-RemoteSmtpServersTls.ps1
@@ -144,7 +144,7 @@ foreach($Server in $Servers) {
   Write-Verbose -Message ('Working on Server {0} | {1}' -f $Server, $Path)
 
   # fetching log files requires an account w/ administrative access to the target server
-  $LogFiles = Get-ChildItem -Path $Path -File | Where-Object {$_.LastWriteTime -gt (Get-Date).AddDays($AddDays)} | Select-Object -First 2
+  $LogFiles = Get-ChildItem -Path $Path -File | Where-Object {$_.LastWriteTime -gt (Get-Date).AddDays($AddDays)}
 
   $LogFileCount = ($LogFiles | Measure-Object).Count
   

--- a/Get-RemoteSmtpServersTls.ps1
+++ b/Get-RemoteSmtpServersTls.ps1
@@ -174,7 +174,7 @@ foreach($Server in $Servers) {
         $HostIp = (($record.Line).Split(',')[5]).Split(':')[0]
 
         # Try to resolve remote IP address as the line does not contain a server name
-        $HostName = Resolve-DnsName $HostIp -ErrorAction Ignore |Select-Object -ExpandProperty NameHost
+        $HostName = Resolve-DnsName $HostIp -ErrorAction Ignore |Select-Object -ExpandProperty NameHost -ErrorAction Ignore
 
         if(-not $RemoteServers.Contains($HostName)) { 
           $RemoteServers += $HostName

--- a/Get-RemoteSmtpServersTls.ps1
+++ b/Get-RemoteSmtpServersTls.ps1
@@ -176,9 +176,18 @@ foreach($Server in $Servers) {
         # Try to resolve remote IP address as the line does not contain a server name
         $HostName = Resolve-DnsName $HostIp -ErrorAction Ignore |Select-Object -ExpandProperty NameHost -ErrorAction Ignore
 
-        if(-not $RemoteServers.Contains($HostName)) { 
-          $RemoteServers += $HostName
+        if ($null -ne $HostName)
+        {
+          if(-not $RemoteServers.Contains($HostName)) { 
+            $RemoteServers += $HostName
+          }
         }
+        else {
+          if(-not $RemoteServers.Contains($HostIp)) { 
+            $RemoteServers += $HostIp
+          }
+        }
+        
       }
 
       $FileCount++

--- a/Get-RemoteSmtpServersTls.ps1
+++ b/Get-RemoteSmtpServersTls.ps1
@@ -62,8 +62,6 @@ param(
   [int]$AddDays = -10
 )
 
-$ScriptDir = Split-Path -Path $script:MyInvocation.MyCommand.Path
-
 $CsvFileName = ('RemoteSMTPServersTls-%SERVER%-%ROLE%-%TLS%-{0}.csv' -f ((Get-Date).ToString('s').Replace(':','-')))
 
 # ToDo: Update to Get-TransportServer/Get-TransportService 


### PR DESCRIPTION
- Fixed a bug when NameHost is $null because host couldn't be resolved
- Add ip address instead of host name if the host couldn't be resolved